### PR TITLE
refactor(ContentView): remove unused properties from defaultProperties dictionary

### DIFF
--- a/ConfigForge/Views/ContentView.swift
+++ b/ConfigForge/Views/ContentView.swift
@@ -319,9 +319,7 @@ struct ModernEntryEditorView: View {
             let defaultProperties: [String: String] = [
                 "HostName": "",
                 "User": "",
-                "Port": "22",
-                "IdentityFile": "",
-                "PreferredAuthentications": "publickey"
+                "Port": "22"
             ]
             _editedProperties = State(initialValue: defaultProperties)
         } else {


### PR DESCRIPTION
This commit simplifies the defaultProperties dictionary in the ModernEntryEditorView by removing the "IdentityFile" and "PreferredAuthentications" entries, which were not necessary for the current implementation.

Signed-off-by: samzong <samzong.lu@gmail.com>

## Description

Briefly describe the purpose and changes in this Pull Request.

## Change Type

- [ ] Bug fix (bug fix)
- [ ] New feature (new feature)
- [ ] Code improvement (code improvement)
- [ ] Documentation update (documentation)
- [ ] Build/CI related changes (build/CI)
- [ ] Other (please specify in the description)

## Related Issues

Please link the issue this PR solves (if any).
For example: Fixes #123

## Testing

Please describe the tests you performed and the environments you tested in.

- [ ] Tested on Intel Mac
- [ ] Tested on Apple Silicon Mac
- [ ] Unit tests passed
- [ ] UI tests passed

## Screenshots

If applicable, add screenshots to help explain your changes.

## Checklist

- [ ] My code follows the project's code style
- [ ] I have performed self-testing
- [ ] I have updated the relevant documentation (if applicable)
- [ ] My changes do not introduce new warnings or errors
- [ ] My changes are compatible with Intel and Apple Silicon architectures

## Additional Information

Any other information that reviewers need to know.

